### PR TITLE
Add flight search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ MyAirline Reservation Management System is a web-based application for handling 
 
 ---
 This project showcases my exploration of Spring Boot and web development.
+### Searching for Flights
+
+After logging in, users can search for available flights by providing a start and end location:
+
+```http
+GET /api/v1/flights/search?start=COLOMBO&end=DUBAI
+```
+
+The endpoint returns a JSON list of matching flights with seat availability and distance information.

--- a/src/main/java/com/myairline/arms/controller/FlightController.java
+++ b/src/main/java/com/myairline/arms/controller/FlightController.java
@@ -1,0 +1,26 @@
+package com.myairline.arms.controller;
+
+import com.myairline.arms.dto.Planedto;
+import com.myairline.arms.service.PlaneService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/flights")
+@RequiredArgsConstructor
+public class FlightController {
+
+    private final PlaneService planeService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Planedto>> searchFlights(
+            @RequestParam String start,
+            @RequestParam String end
+    ) {
+        List<Planedto> flights = planeService.searchPlanes(start, end);
+        return ResponseEntity.ok(flights);
+    }
+}

--- a/src/main/java/com/myairline/arms/repo/PlaneRepo.java
+++ b/src/main/java/com/myairline/arms/repo/PlaneRepo.java
@@ -14,5 +14,8 @@ public interface PlaneRepo extends JpaRepository<AirPlane,Integer> {
     @Query("SELECT  a FROM AirPlane a WHERE a.start = ?1 AND a.end = ?2")
     AirPlane findByStartAndEnd(String start,String end);
 
+    @Query("SELECT a FROM AirPlane a WHERE a.start = :start AND a.end = :end")
+    List<AirPlane> findAllByRoute(@Param("start") String start, @Param("end") String end);
+
     Optional<AirPlane> findById(int id);
 }

--- a/src/main/java/com/myairline/arms/service/PlaneService.java
+++ b/src/main/java/com/myairline/arms/service/PlaneService.java
@@ -67,6 +67,11 @@ public class PlaneService {
         return modelMapper.map(airPlanes, new TypeToken<List<Planedto>>(){}.getType());
     }
 
+    public List<Planedto> searchPlanes(String start, String end) {
+        List<AirPlane> airPlanes = planeRepo.findAllByRoute(start, end);
+        return modelMapper.map(airPlanes, new TypeToken<List<Planedto>>(){}.getType());
+    }
+
     public ResponseEntity<String> deletePlaneById(int id) {
         Planedto existOne = getPlaneById(id);
         planeRepo.delete(modelMapper.map(existOne,AirPlane.class));


### PR DESCRIPTION
## Summary
- extend `PlaneService` with `searchPlanes`
- update `PlaneRepo` to support flight searches
- add `FlightController` with new REST endpoint
- document flight search in README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685fd4fcc53883208232f44e988a3c50